### PR TITLE
feat(workflow): version and tag update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,20 @@
 name: Releases
 
-on: 
+on:
   push:
     tags:
-    - '*'
+      - '*.*.*'
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-    - uses: actions/checkout@v3
-    - uses: ncipollo/release-action@v1.14.0
-      with:
-        body: "See: https://github.com/astral-sh/uv/releases/tag/${{ github.ref_name }}"
+      - uses: actions/checkout@v3
+
+      - run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          gh release create "$TAG_NAME" \
+            --title "$TAG_NAME" \
+            --notes "See: https://github.com/astral-sh/uv/releases/tag/$TAG_NAME"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Releases
+
+on: 
+  push:
+    tags:
+    - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ncipollo/release-action@v1.14.0
+      with:
+        body: "See: https://github.com/astral-sh/uv/releases/tag/${{ github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Releases
 on:
   push:
     tags:
-      - '*.*.*'
+      - '[0-9]+.[0-9]+.[0-9]*'
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To compile your requirements via pre-commit, add the following to your `.pre-com
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: v0.1.24
+  rev: 0.1.24
   hooks:
     # Run the pip compile
     - id: pip-compile
@@ -31,7 +31,7 @@ To compile alternative files, modify the `args` and `files`:
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: v0.1.24
+  rev: 0.1.24
   hooks:
     # Run the pip compile
     - id: pip-compile
@@ -44,7 +44,7 @@ To run the hook over multiple files at the same time:
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: v0.1.24
+  rev: 0.1.24
   hooks:
     # Run the pip compile
     - id: pip-compile

--- a/mirror.py
+++ b/mirror.py
@@ -20,11 +20,11 @@ def main():
     for version in target_versions:
         paths = process_version(version)
         if subprocess.check_output(["git", "status", "-s"]).strip():
-            subprocess.run(["git", "add", *paths])
-            subprocess.run(["git", "commit", "-m", f"Mirror: {version}"])
-            subprocess.run(["git", "tag", f"v{version}"])
+            subprocess.run(["git", "add", *paths], check=True)
+            subprocess.run(["git", "commit", "-m", f"Mirror: {version}"], check=True)
+            subprocess.run(["git", "tag", f"{version}"], check=True)
         else:
-            print(f"No change v{version}")
+            print(f"No change {version}")
 
 
 def get_all_versions() -> list[Version]:
@@ -54,7 +54,7 @@ def process_version(version: Version) -> typing.Sequence[str]:
         return re.sub(r'"uv==.*"', f'"uv=={version}"', content)
 
     def replace_readme_md(content: str) -> str:
-        content = re.sub(r"rev: v\d+\.\d+\.\d+", f"rev: v{version}", content)
+        content = re.sub(r"rev: \d+\.\d+\.\d+", f"rev: {version}", content)
         return re.sub(r"/uv/\d+\.\d+\.\d+\.svg", f"/uv/{version}.svg", content)
 
     paths = {


### PR DESCRIPTION
## feat(mirror): remove `v` from version
    
As mentioned in https://github.com/astral-sh/uv-pre-commit/issues/5, `uv` does not use `v` in its version tagging. Considering that this repo is primarily a mirror of the `uv` repo, it should match.

## feat(workflow): auto release on tag creation
    
Although this functionality is not required, some users might be confused if the tag and release version are not the same. This in reference to https://github.com/astral-sh/uv-pre-commit/issues/4
    
Additionally, the body of the release points to the uv release
