### PR TITLE
Corrected version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To compile your requirements via pre-commit, add the following to your `.pre-com
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.1.24
+  rev: v0.1.24
   hooks:
     # Run the pip compile
     - id: pip-compile
@@ -31,7 +31,7 @@ To compile alternative files, modify the `args` and `files`:
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.1.24
+  rev: v0.1.24
   hooks:
     # Run the pip compile
     - id: pip-compile
@@ -44,7 +44,7 @@ To run the hook over multiple files at the same time:
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.1.24
+  rev: v0.1.24
   hooks:
     # Run the pip compile
     - id: pip-compile


### PR DESCRIPTION
The hook version used in the pre-commit config examples throughout the README does not match the convention actually being used to tag versions in this repository. 