### PR TITLE
feat: uv lock pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,4 +8,13 @@
   pass_filenames: false
   additional_dependencies: []
   minimum_pre_commit_version: "2.9.2"
-
+- id: uv-lock
+  name: uv-lock
+  description: "Automatically run 'uv lock' on your project dependencies"
+  entry: uv lock
+  language: python
+  files: ^(requirements\.(in|txt)|pyproject\.toml|uv\.toml)$
+  args: []
+  pass_filenames: false
+  additional_dependencies: []
+  minimum_pre_commit_version: "2.9.2"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,7 +13,7 @@
   description: "Automatically run 'uv lock' on your project dependencies"
   entry: uv lock
   language: python
-  files: ^uv.lock$
+  files: ^(uv\.lock|pyproject\.toml|uv\.toml)$
   args: []
   pass_filenames: false
   additional_dependencies: []

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,7 +13,7 @@
   description: "Automatically run 'uv lock' on your project dependencies"
   entry: uv lock
   language: python
-  files: ^(requirements\.(in|txt)|pyproject\.toml|uv\.toml)$
+  files: ^uv.lock$
   args: []
   pass_filenames: false
   additional_dependencies: []

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ To run the hook over multiple files at the same time:
       files: ^requirements-dev\.(in|txt)$
 ```
 
+To check if the the lockfile is consistent with your dependencies (either with compiled requirements or toml):
+
+```yaml
+- repo: https://github.com/astral-sh/uv-pre-commit
+  # uv version.
+  rev: 0.3.0
+  hooks:
+    # Run the uv lock
+    - id: uv-lock
+      name: uv-lock
+      entry: uv lock
+      args: [--locked]
+```
+
 ## License
 
 uv-pre-commit is licensed under either of

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ To check if the the lockfile is consistent with your dependencies (either with c
   # uv version.
   rev: 0.3.0
   hooks:
-    # Run the uv lock
+    # Update the uv lockfile
     - id: uv-lock
       name: uv-lock
       entry: uv lock
-      args: [--locked]
+      args: []
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To run the hook over multiple files at the same time:
       files: ^requirements-dev\.(in|txt)$
 ```
 
-To check if the the lockfile is consistent with your dependencies (either with compiled requirements or toml):
+To ensure the lockfile is up-to-date:
 
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit

--- a/README.md
+++ b/README.md
@@ -65,9 +65,6 @@ To check if the the lockfile is consistent with your dependencies (either with c
   hooks:
     # Update the uv lockfile
     - id: uv-lock
-      name: uv-lock
-      entry: uv lock
-      args: []
 ```
 
 ## License


### PR DESCRIPTION
Adds a check so a new package added manually without say, `uv add` errors:

```
.venv/bin/python -m pre_commit run --all-files
check json...............................................................Passed
check toml...............................................................Passed
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
Detect secrets...........................................................Passed
Lint GitHub Actions workflow files.......................................Passed
uv-lock..................................................................Failed
- hook id: uv-lock
- exit code: 2

Resolved N packages in Ns
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.

ruff.....................................................................Passed
ruff-format..............................................................Passed
```

Cross linking https://github.com/astral-sh/uv/issues/6355