### PR TITLE
Add uv sync hook to automatically sync envs after checkout or merge

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -28,3 +28,12 @@
   pass_filenames: false
   additional_dependencies: []
   minimum_pre_commit_version: "2.9.2"
+- id: uv-sync
+  name: uv-sync
+  description: "Automatically run 'uv sync' post merge or checkout"
+  entry: uv sync
+  args: ["--locked"]
+  language: python
+  pass_filenames: false
+  stages: [post-checkout, post-merge]
+  always_run: true

--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ To export to an alternative file, modify the `args`:
       args: ["--frozen", "--output-file=requirements-custom.txt"]
 ```
 
+To make sure all locked packages are installed:
+
+```yaml
+- repo: https://github.com/astral-sh/uv-pre-commit
+  # uv version.
+  rev: 0.4.28
+  hooks:
+    - id: uv-sync
+```
+In order to install this hook, you either need to specify `default_install_hook_types`, or you have
+to install it via `pre-commit install --install-hooks -t post-checkout -t post-merge`.
+
 ## License
 
 uv-pre-commit is licensed under either of


### PR DESCRIPTION
This ensures anytime a merge or checkout occurs, the local python environment is synced. 
This is especially useful when working in a team or with tools like dependabot that are constantly upgrading dependencies. 

I added the 

This serves the same purpose as the `poetry-install` [pre-commit hook](https://github.com/python-poetry/poetry/blob/main/.pre-commit-hooks.yaml#L17-L24) (and is widely inspired from it)
Closes #17 