### PR TITLE
Add `--no-active` to uv-sync hook to silence warning

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -11,7 +11,7 @@
 - id: uv-lock
   name: uv-lock
   description: "Automatically run 'uv lock' on your project dependencies"
-  entry: uv lock --no-active
+  entry: uv lock
   language: python
   files: ^(uv\.lock|pyproject\.toml|uv\.toml)$
   args: []

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -11,7 +11,7 @@
 - id: uv-lock
   name: uv-lock
   description: "Automatically run 'uv lock' on your project dependencies"
-  entry: uv lock
+  entry: uv lock --no-active
   language: python
   files: ^(uv\.lock|pyproject\.toml|uv\.toml)$
   args: []
@@ -31,7 +31,7 @@
 - id: uv-sync
   name: uv-sync
   description: "Automatically run 'uv sync' on your repository after a checkout, pull or rebase"
-  entry: uv sync
+  entry: uv sync --no-active
   args: ["--locked"]
   language: python
   always_run: true


### PR DESCRIPTION
Add `--no-active` option to `uv-sync` to ignore the pre-commit virtual env. Closes #36.

As far as I can tell, the other hooks don't support/need this option, but would like that confirmed.

### Testing

To test this PR, add the following to `.pre-commit-config.yaml`

```
  - repo: https://github.com/danielhollas/uv-pre-commit    
    rev: fc377b7
    hooks:    
    - id: uv-sync                                                                                                                         
      verbose: true
      stages: [pre-commit]
```

and run

```console
pre-commit run -a uv-sync
```

No warning should be printed.