### PR TITLE
Use `--quiet` by default in `uv-export`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -24,7 +24,7 @@
   entry: uv export
   language: python
   files: ^uv\.lock$
-  args: ["--frozen", "--output-file=requirements.txt"]
+  args: ["--frozen", "--output-file=requirements.txt", "--quiet"]
   pass_filenames: false
   additional_dependencies: []
   minimum_pre_commit_version: "2.9.2"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To autoexport `uv.lock` to `requirements.txt`:
     - id: uv-export
 ```
 
-By default, this will use the ["quiet" output](https://docs.astral.sh/uv/reference/cli/#uv-export--quiet).
+By default, this hook uses the ["quiet" output](https://docs.astral.sh/uv/reference/cli/#uv-export--quiet).
 
 To export to an alternative file, modify the `args`:
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ To autoexport `uv.lock` to `requirements.txt`:
     - id: uv-export
 ```
 
+By default, this will use the ["quiet" output](https://docs.astral.sh/uv/reference/cli/#uv-export--quiet).
+
 To export to an alternative file, modify the `args`:
 
 ```yaml
@@ -44,7 +46,7 @@ To export to an alternative file, modify the `args`:
   rev: 0.8.4
   hooks:
     - id: uv-export
-      args: ["--frozen", "--output-file=requirements-custom.txt"]
+      args: ["--frozen", "--output-file=requirements-custom.txt", "--quiet"]
 ```
 
 To compile your requirements via pre-commit, add the following to your `.pre-commit-config.yaml`:


### PR DESCRIPTION
Hi,

First time interacting with a `astral-sh` repo, so first of all thank you very much for developing amazing tools like `uv` an `ruff`. :)

In this PR, I am proposing to use the quiet output by default in the `uv-export` hook.
Currently the hook will also print the whole export. This output (which also includes hashes) that can quickly become very very long and therefore it makes it harder to inspect the rest of `pre-commit` results.
IMO verbose outputs in `pre-commit` hooks make sense when they show specific actionable errors (e.g. `ruff` or typing errors). In this case, the hook could simplify just fail and regenerate the file:

```console
$ pre-commit run --all-files
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check toml...............................................................Passed
check yaml...............................................................Passed
check json...............................................................Passed
check for merge conflicts................................................Passed
check for added large files..............................................Passed
debug statements (python)................................................Passed
detect private key.......................................................Passed
ruff.....................................................................Passed
uv-export................................................................Failed
- hook id: uv-export
- files were modified by this hook
```

This is a bit of personal preference I guess, so happy to close this PR if you don't agree :)