### PR TITLE
Add a uv-audit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -38,3 +38,13 @@
   pass_filenames: false
   stages: [post-checkout, post-merge, post-rewrite]
   minimum_pre_commit_version: "2.9.2"
+- id: uv-audit
+  name: uv-audit
+  description: "Automatically run 'uv audit' on your project dependencies"
+  entry: uv audit
+  language: python
+  files: ^(uv\.lock|pyproject\.toml|uv\.toml)$
+  args: []
+  pass_filenames: false
+  additional_dependencies: []
+  minimum_pre_commit_version: "2.9.2"


### PR DESCRIPTION
NB: I'm not the most familiar with pre-commit configs, so this could use a close scan 🙂. I copied the other hooks and tweaked based on my understanding of how they work (e.g we have `pass_filenames: false` here since `uv audit` doesn't take any inputs).

Closes #64.