### PR TITLE
Modify file pattern for uv-export hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -23,7 +23,7 @@
   description: "Automatically run 'uv export' on your project dependencies"
   entry: uv export
   language: python
-  files: ^uv\.lock$
+  files: ^(uv\.lock|pyproject\.toml|uv\.toml)$
   args: ["--frozen", "--output-file=requirements.txt", "--quiet"]
   pass_filenames: false
   additional_dependencies: []


### PR DESCRIPTION
While `uv export` only cares about changes of the `uv.lock` file, I guess this is often used in combination with the `uv-lock` hook. To prevent yet another commit iteration, the hook could directly trigger on `pyproject.toml` files changes, which will cause a `uv.lock` change.