### PR TITLE
Force UV_FROZEN=0 for uv-lock hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -11,7 +11,7 @@
 - id: uv-lock
   name: uv-lock
   description: "Automatically run 'uv lock' on your project dependencies"
-  entry: uv lock
+  entry: env UV_FROZEN=0 uv lock
   language: python
   files: ^(uv\.lock|pyproject\.toml|uv\.toml)$
   args: []


### PR DESCRIPTION
Closes #70.

When `UV_FROZEN=1` is set in the environment (common in CI), `uv lock` enables its `--check-exists` semantics: it verifies that `uv.lock` exists but does not check if it is up-to-date and does not update it. The `uv-lock` pre-commit hook then passes even when `pyproject.toml` has drifted from `uv.lock`, so lockfile drift can slip through pre-commit unnoticed.

This PR prefixes the hook's entry with `env UV_FROZEN=0` so it always exercises the "update the lockfile" path regardless of what the surrounding environment sets. Users who want a check-only variant can still call `uv lock --check` directly.

Marked as draft — happy to switch to a different approach (e.g. `entry: env -u UV_FROZEN uv lock`, or `args: ["--check"]` as a behavior change) if the maintainers prefer.

Portability note: this relies on `env` being on PATH, which is true on POSIX systems. Not sure how it fares for pre-commit users on Windows — feedback welcome.