### PR TITLE
feat: standardise release names to vX.Y.Z format

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To ensure the lockfile is up-to-date:
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.11.29
+  rev: v0.11.29
   hooks:
     # Update the uv lockfile
     - id: uv-lock
@@ -31,7 +31,7 @@ To autoexport `uv.lock` to `requirements.txt`:
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.11.29
+  rev: v0.11.29
   hooks:
     - id: uv-export
 ```
@@ -43,7 +43,7 @@ To export to an alternative file, modify the `args`:
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.11.29
+  rev: v0.11.29
   hooks:
     - id: uv-export
       args: ["--frozen", "--output-file=requirements-custom.txt", "--quiet"]
@@ -54,7 +54,7 @@ To compile your requirements via pre-commit, add the following to your `.pre-com
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.11.29
+  rev: v0.11.29
   hooks:
     # Run the pip compile
     - id: pip-compile
@@ -66,7 +66,7 @@ To compile alternative files, modify the `args` and `files`:
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.11.29
+  rev: v0.11.29
   hooks:
     # Run the pip compile
     - id: pip-compile
@@ -79,7 +79,7 @@ To run the hook over multiple files at the same time:
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.11.29
+  rev: v0.11.29
   hooks:
     # Run the pip compile
     - id: pip-compile
@@ -96,7 +96,7 @@ To run a hook on a project within a subdirectory (i.e., in a monorepo):
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.11.29
+  rev: v0.11.29
   hooks:
     # Update the uv lockfile
     - id: uv-lock
@@ -116,7 +116,7 @@ default_install_hook_types:
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.29
+    rev: v0.11.29
     hooks:
       - id: uv-sync
 ```
@@ -129,7 +129,7 @@ To synchronize all dependencies in a workspace:
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.11.29
+  rev: v0.11.29
   hooks:
     - id: uv-sync
       args: ["--locked", "--all-packages"]
@@ -141,7 +141,7 @@ include it as an additional sync dependency:
 ```yaml
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.11.29
+  rev: v0.11.29
   hooks:
     - id: uv-sync
       additional_dependencies: [keyring]

--- a/mirror.py
+++ b/mirror.py
@@ -21,8 +21,8 @@ def main():
         paths = process_version(version)
         if subprocess.check_output(["git", "status", "-s"]).strip():
             subprocess.run(["git", "add", *paths], check=True)
-            subprocess.run(["git", "commit", "-m", f"Mirror: {version}"], check=True)
-            subprocess.run(["git", "tag", f"{version}"], check=True)
+            subprocess.run(["git", "commit", "-m", f"Mirror: v{version}"], check=True)
+            subprocess.run(["git", "tag", f"v{version}"], check=True)
         else:
             print(f"No change {version}")
 
@@ -54,8 +54,8 @@ def process_version(version: Version) -> typing.Sequence[str]:
         return re.sub(r'"uv==.*"', f'"uv=={version}"', content)
 
     def replace_readme_md(content: str) -> str:
-        content = re.sub(r"rev: \d+\.\d+\.\d+", f"rev: {version}", content)
-        return re.sub(r"/uv/\d+\.\d+\.\d+\.svg", f"/uv/{version}.svg", content)
+        content = re.sub(r"rev: v?\d+\.\d+\.\d+", f"rev: v{version}", content)
+        return re.sub(r"/uv/v?\d+\.\d+\.\d+\.svg", f"/uv/v{version}.svg", content)
 
     paths = {
         "pyproject.toml": replace_pyproject_toml,


### PR DESCRIPTION
Tags and releases now follow the vX.Y.Z convention (e.g. v0.11.29) consistent with ruff-pre-commit and other Astral pre-commit repos.

- mirror.py: prefix git tag and commit message with 'v'
- mirror.py: update README regex to emit and match v-prefixed rev/badge (uses v? so it handles both bare and v-prefixed inputs idempotently)
- README.md: update all existing rev: pins to v-prefixed format

Closes #50